### PR TITLE
Allow public access to data and size in Buffer.

### DIFF
--- a/src/main/java/ru/eustas/zopfli/Buffer.java
+++ b/src/main/java/ru/eustas/zopfli/Buffer.java
@@ -28,6 +28,14 @@ public class Buffer {
     data = new byte[65536];
   }
 
+  public byte[] getData() {
+    return data;
+  }
+
+  public int getSize() {
+    return size;
+  }
+
   void append(byte value) {
     if (size == data.length) {
       byte[] copy = new byte[size * 2];


### PR DESCRIPTION
In order to use Zopfli.compress outside of its own package (ru.eustas.zopfli), Buffer needs to allow permission to access the data and size.

The use case I'm referring to is while in some other package:

Zopfli compressor = new Zopfli(MASTER_BLOCK_SIZE);
Buffer buffer = compressor.compress(options, bytesIn);

FileOutputStream fos = null;
fos = new FileOutputStream(pathOut.toFile());
fos.write(buffer.data, 0, buffer.size); // These accesses will fail because data and size are package private